### PR TITLE
Fix the issue that data too long let uapi hold, and support for configuring specified server

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ windows 中 `wg-go` 默认使用的 pipe 来实现 ipc ，但是我发现权限�
   // will use corplink as interface name
   "interface_name": "corplink",
   // will use wg-corplink as wireguard-go
-  "wg_binary": "wg-corplink"
+  "wg_binary": "wg-corplink",
+  // will use the specified server to connect, for example 'HK-1'
+  // default is null, it's response the first vpn server returned by the 'listvpn' API will be used
+  "vpn_server_name": null
 }
 ```
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,8 @@ pub const URL_GET_COMPANY: &str = "https://corplink.volcengine.cn/api/match";
 
 const URL_GET_LOGIN_METHOD: &str = "{{url}}/api/login/setting?os={{os}}&os_version={{version}}";
 const URL_GET_TPS_LOGIN_METHOD: &str = "{{url}}/api/tpslogin/link?os={{os}}&os_version={{version}}";
-const URL_GET_TPS_TOEKN_CHECK: &str = "{{url}}/api/tpslogin/token/check?os={{os}}&os_version={{version}}";
+const URL_GET_TPS_TOEKN_CHECK: &str =
+    "{{url}}/api/tpslogin/token/check?os={{os}}&os_version={{version}}";
 const URL_GET_CORPLINK_LOGIN_METHOD: &str = "{{url}}/api/lookup?os={{os}}&os_version={{version}}";
 const URL_REQUEST_CODE: &str = "{{url}}/api/login/code/send?os={{os}}&os_version={{version}}";
 const URL_VERIFY_CODE: &str = "{{url}}/api/login/code/verify?os={{os}}&os_version={{version}}";
@@ -65,9 +66,18 @@ impl ApiUrl {
         let mut api_template = HashMap::new();
 
         api_template.insert(ApiName::LoginMethod, Template::new(URL_GET_LOGIN_METHOD));
-        api_template.insert(ApiName::TpsLoginMethod, Template::new(URL_GET_TPS_LOGIN_METHOD));
-        api_template.insert(ApiName::TpsTokenCheck, Template::new(URL_GET_TPS_TOEKN_CHECK));
-        api_template.insert(ApiName::CorplinkLoginMethod, Template::new(URL_GET_CORPLINK_LOGIN_METHOD));
+        api_template.insert(
+            ApiName::TpsLoginMethod,
+            Template::new(URL_GET_TPS_LOGIN_METHOD),
+        );
+        api_template.insert(
+            ApiName::TpsTokenCheck,
+            Template::new(URL_GET_TPS_TOEKN_CHECK),
+        );
+        api_template.insert(
+            ApiName::CorplinkLoginMethod,
+            Template::new(URL_GET_CORPLINK_LOGIN_METHOD),
+        );
         api_template.insert(ApiName::RequestEmailCode, Template::new(URL_REQUEST_CODE));
         api_template.insert(ApiName::LoginEmail, Template::new(URL_VERIFY_CODE));
         api_template.insert(ApiName::LoginPassword, Template::new(URL_LOGIN_PASSWORD));
@@ -76,8 +86,6 @@ impl ApiUrl {
         api_template.insert(ApiName::ConnectVPN, Template::new(URL_FETCH_PEER_INFO));
         api_template.insert(ApiName::KeepAliveVPN, Template::new(URL_OPERATE_VPN));
         api_template.insert(ApiName::DisconnectVPN, Template::new(URL_OPERATE_VPN));
-
-        
 
         ApiUrl {
             user_param: UserUrlParam {

--- a/src/client.rs
+++ b/src/client.rs
@@ -577,11 +577,18 @@ impl Client {
         let vpn_info = self.list_vpn().await?;
         let mut avalaible = false;
 
-        println!("found {} vpn(s), details: {:?}", vpn_info.len(), vpn_info.iter().map(|i| i.en_name.clone()).collect::<Vec<String>>());
+        println!(
+            "found {} vpn(s), details: {:?}",
+            vpn_info.len(),
+            vpn_info
+                .iter()
+                .map(|i| i.en_name.clone())
+                .collect::<Vec<String>>()
+        );
         let mut vpn_addr = String::new();
         for vpn in vpn_info {
-            if let Some(server_name) =  self.conf.vpn_server_name.clone() {
-                if vpn.en_name != server_name{
+            if let Some(server_name) = self.conf.vpn_server_name.clone() {
+                if vpn.en_name != server_name {
                     println!("skip {}, expect {}", vpn.en_name, server_name);
                     continue;
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -577,9 +577,15 @@ impl Client {
         let vpn_info = self.list_vpn().await?;
         let mut avalaible = false;
 
-        println!("found {} vpn(s)", vpn_info.len());
+        println!("found {} vpn(s), details: {:?}", vpn_info.len(), vpn_info.iter().map(|i| i.en_name.clone()).collect::<Vec<String>>());
         let mut vpn_addr = String::new();
         for vpn in vpn_info {
+            if let Some(server_name) =  self.conf.vpn_server_name.clone() {
+                if vpn.en_name != server_name{
+                    println!("skip {}, expect {}", vpn.en_name, server_name);
+                    continue;
+                }
+            }
             let mode = match vpn.protocol_mode {
                 1 => "tcp",
                 2 => "udp",

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
     #[serde(skip_serializing)]
     pub conf_file: Option<String>,
     pub state: Option<State>,
+    pub vpn_server_name: Option<String>,
 }
 
 impl fmt::Display for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,6 @@ pub const PLATFORM_DING_TALK: &str = "dingtalk";
 // unknown
 pub const PLATFORM_AAD: &str = "aad";
 
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
     pub company_name: String,

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -154,13 +154,16 @@ impl UAPIClient {
         }
         // end operation
         buff.push('\n');
-        let data = buff.as_bytes();
+        let mut data = buff.as_bytes();
 
         println!("send config to uapi");
-        match conn.write(data).await {
-            Ok(_) => {}
-            Err(err) => {
-                return Err(err);
+        while !data.is_empty() {
+            match conn.write(data).await {
+                Ok(n) if n > 0 => {
+                    data = &data[n..];
+                }
+                Ok(_) => break,
+                Err(err) => return Err(err),
             }
         }
         conn.flush().await?;

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -221,7 +221,8 @@ impl UAPIClient {
                                         // do nothing because it's invalid
                                     } else {
                                         let nt =
-                                            chrono::NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap();
+                                            chrono::NaiveDateTime::from_timestamp_opt(timestamp, 0)
+                                                .unwrap();
                                         let now = chrono::Utc::now().naive_utc();
                                         let t = now - nt;
                                         let tt: chrono::DateTime<chrono::Utc> =


### PR DESCRIPTION
Thank you for your making this open and available, I found a problem in my environment. 
- If there too many routes, the UnixStream write may only write 8192 length data, and remaining is not write to it then flush. This make the uapi stream read block. and the debug report there has error/invalid config.

Try to fix it, and support for configuring specified server.
PTAL @PinkD 