### PR TITLE
fix: kill old wg process when starting corplink-rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod wg;
 #[cfg(windows)]
 use is_elevated;
 use std::{env, process::exit};
-
+use std::process::Command;
 use client::Client;
 use config::{Config, WgConf};
 
@@ -59,6 +59,8 @@ async fn main() {
 
     let conf_file = parse_arg();
     let mut conf = Config::from_file(&conf_file).await;
+
+    kill_process_if_exists(config::DEFAULT_CMD_WG_NAME);
 
     let cmd = match conf.wg_binary.clone() {
         Some(cmd) => cmd,
@@ -209,4 +211,14 @@ fn print_version() {
     let pkg_name = env!("CARGO_PKG_NAME");
     let pkg_version = env!("CARGO_PKG_VERSION");
     println!("running {}@{}", pkg_name, pkg_version);
+}
+
+fn kill_process_if_exists(process_name: &str) {
+    let output = Command::new("pkill")
+        .arg(process_name)
+        .output()
+        .expect("Failed to execute pkill command");
+     if output.status.success() {
+        println!("Process {} killed successfully", process_name);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,14 +248,15 @@ fn kill_process_if_exists(process_name: &str, interface_name: &str) {
 
 #[cfg(windows)]
 fn kill_process(process_name: &str, interface_name: &str) {
-    let full_command = format!("{} -f {}", process_name, interface_name);
+    let full_command = format!(
+        r#"Path win32_process Where "CommandLine Like '%-f {}%' And Name Like '{}'" Call Terminate"#,
+        interface_name, process_name
+    );
 
-    let output = std::process::Command::new("taskkill")
-        .arg("/F")
-        .arg("/IM")
+    let output = std::process::Command::new("wmic")
         .arg(&full_command)
         .output()
-        .expect("Failed to execute taskkill command");
+        .expect("Failed to execute wmic command");
 
     if output.status.success() {
         println!("Process with interface named {} killed successfully", interface_name);


### PR DESCRIPTION
### Desc
fix a timeout issue caused by old wg process on MacOS

ref: https://github.com/PinkD/corplink-rs/issues/14

### Test on MacOS
before starting `corplink-rs`, the old wg PID is 38944
```
ps aux | grep corplink                                                                                                                       
root             38944   0.6  0.1 409215312   8896 s000  S     5:44PM   0:00.11 wg-corplink -f utun5
lannister        39070   0.0  0.0 408495824   1072 s003  R+    5:45PM   0:00.00 grep corplink
```

after starting `corplink-rs`, the old process was killed, the new wg PID is 39128
```
ps aux | grep corplink                                                                                                                       
lannister        39223   0.0  0.0 407962000    176 s003  R+    5:45PM   0:00.00 grep corplink
root             39128   0.0  0.0 409213616   7408 s000  S+    5:45PM   0:00.06 wg-corplink -f utun5
root             39087   0.0  0.1 409008336   9344 s000  S+    5:45PM   0:00.03 /Users/lannister/pragmatic/corplink-rs/target/release/corplink-rs config/config.json
root             39086   0.0  0.0 408649072   6720 s000  S+    5:45PM   0:00.02 /usr/bin/sudo /Users/lannister/pragmatic/corplink-rs/target/release/corplink-rs config/config.json
lannister        39083   0.0  0.0 408554688   3968 s000  S+    5:45PM   0:00.01 /Users/lannister/pragmatic/corplink-rs/target/release/corplink-rs config/config.json
```
### Test on Ubuntu

before starting:
```
lannister@ubuntu:/Users/lannister/corplink/corplink-rs$ ps aux | grep corplink
root         346  0.0  0.0 712368  3712 ?        Sl   18:08   0:00 wg-corplink -f corplink
lannist+     416  0.0  0.0   3056  1280 pts/1    S+   18:09   0:00 grep --color=auto corplink
```

after starting, killed old wg process:
```
lannister@ubuntu:/Users/lannister/corplink/corplink-rs$ ps aux | grep corplink
lannist+     417  0.0  0.0 689852  5120 pts/2    Sl+  18:09   0:00 /Users/lannister/corplink/corplink-rs/target/release/corplink-rs ../config.json
root         428  0.0  0.0   8436  3840 pts/2    S+   18:09   0:00 /usr/bin/sudo /Users/lannister/corplink/corplink-rs/target/release/corplink-rs ../config.json
root         429  0.0  0.0   8436  1548 pts/4    Ss   18:09   0:00 /usr/bin/sudo /Users/lannister/corplink/corplink-rs/target/release/corplink-rs ../config.json
root         430  0.4  0.1 758936 11392 pts/4    Sl+  18:09   0:00 /Users/lannister/corplink/corplink-rs/target/release/corplink-rs ../config.json
root         447  0.2  0.0 712624  4480 pts/4    Sl+  18:09   0:00 wg-corplink -f corplink
lannist+     461  0.0  0.0   3056  1280 pts/1    S+   18:09   0:00 grep --color=auto corplink
```


@PinkD pls review