### PR TITLE
client: avoid unwrap on URL without domain; fallback to host_str() fo…

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -131,13 +131,13 @@ impl Client {
                     .insert_raw(&RawCookie::new("device_name", device_name), &server_url);
             }
 
-            if let Some(csrf_token) =
-                cookie_store.get(server_url.domain().unwrap(), "/", "csrf-token")
-            {
-                headers.insert(
-                    "csrf-token",
-                    header::HeaderValue::from_str(csrf_token.value()).unwrap(),
-                );
+            if let Some(domain) = server_url.domain().or_else(|| server_url.host_str()) {
+                if let Some(csrf_token) = cookie_store.get(domain, "/", "csrf-token") {
+                    headers.insert(
+                        "csrf-token",
+                        header::HeaderValue::from_str(csrf_token.value()).unwrap(),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
当 server_url 是 IP 地址而不是域名时，会抛 panic：
```
thread 'main' panicked at src/client.rs:135:54:
called `Option::unwrap()` on a `None` value
```

因此此修复