### PR TITLE
New config option `auto_setup_routes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ RUST_LOG=debug ./corplink-rs config.json
   "vpn_select_strategy": "latency",
   // use vpn dns for macos
   // NOTE: if process doesn't exit gracefully, your dns may not be restored
-  "use_vpn_dns": false
+  "use_vpn_dns": false,
+  // whether to add routes from server into OS routing table, default is true
+  "add_routes": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ RUST_LOG=debug ./corplink-rs config.json
   // use vpn dns for macos
   // NOTE: if process doesn't exit gracefully, your dns may not be restored
   "use_vpn_dns": false,
-  // whether to add routes from server into OS routing table, default is true
-  "add_routes": true
+  // automatically setup system routes (default: true)
+  // set to false if you want to manually configure routes
+  "auto_setup_routes": true
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -823,11 +823,11 @@ impl Client {
             wg_info.setting.v6_route_split.unwrap_or_default(),
         ]
         .concat();
-        let add_routes = self.conf.add_routes.unwrap_or(true);
-        let routes = if add_routes {
+        let auto_setup_routes = self.conf.auto_setup_routes.unwrap_or(true);
+        let routes = if auto_setup_routes {
             allowed_ips.clone()
         } else {
-            log::info!("add_routes is disabled, skip setting routes");
+            log::info!("auto_setup_routes is disabled, skip setting routes");
             Vec::new()
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -818,11 +818,18 @@ impl Client {
         let address6 = (!wg_info.ipv6.is_empty())
             .then_some(format!("{}/128", wg_info.ipv6))
             .unwrap_or("".into());
-        let route = [
+        let allowed_ips = [
             wg_info.setting.vpn_route_split,
             wg_info.setting.v6_route_split.unwrap_or_default(),
         ]
         .concat();
+        let add_routes = self.conf.add_routes.unwrap_or(true);
+        let routes = if add_routes {
+            allowed_ips.clone()
+        } else {
+            log::info!("add_routes is disabled, skip setting routes");
+            Vec::new()
+        };
 
         // corplink config
         let wg_conf = WgConf {
@@ -833,7 +840,8 @@ impl Client {
             public_key,
             private_key,
             peer_key,
-            route,
+            allowed_ips,
+            routes,
             dns,
             protocol: match vpn.protocol_mode {
                 // tcp

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ pub struct Config {
     pub vpn_server_name: Option<String>,
     pub vpn_select_strategy: Option<String>,
     pub use_vpn_dns: Option<bool>,
-    pub add_routes: Option<bool>,
+    pub auto_setup_routes: Option<bool>,
 }
 
 impl fmt::Display for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub vpn_server_name: Option<String>,
     pub vpn_select_strategy: Option<String>,
     pub use_vpn_dns: Option<bool>,
+    pub add_routes: Option<bool>,
 }
 
 impl fmt::Display for Config {
@@ -133,7 +134,8 @@ pub struct WgConf {
     pub public_key: String,
     pub private_key: String,
     pub peer_key: String,
-    pub route: Vec<String>,
+    pub allowed_ips: Vec<String>,
+    pub routes: Vec<String>,
 
     // extra confs
     pub dns: String,

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -75,11 +75,11 @@ impl UAPIClient {
         buff.push_str("replace_allowed_ips=true\n".to_string().as_str());
         buff.push_str(format!("endpoint={}\n", conf.peer_address).as_str());
         buff.push_str("persistent_keepalive_interval=10\n".to_string().as_str());
-        for route in &conf.route {
-            if route.contains("/") {
-                buff.push_str(format!("allowed_ip={route}\n").as_str());
+        for allowed_ip in &conf.allowed_ips {
+            if allowed_ip.contains("/") {
+                buff.push_str(format!("allowed_ip={allowed_ip}\n").as_str());
             } else {
-                buff.push_str(format!("allowed_ip={route}/32\n").as_str());
+                buff.push_str(format!("allowed_ip={allowed_ip}/32\n").as_str());
             }
         }
 
@@ -93,7 +93,7 @@ impl UAPIClient {
         }
         buff.push_str(format!("mtu={mtu}\n").as_str());
         buff.push_str("up=true\n".to_string().as_str());
-        for route in &conf.route {
+        for route in &conf.routes {
             if route.contains("/") {
                 buff.push_str(format!("route={route}\n").as_str());
             } else {


### PR DESCRIPTION
这个配置允许连接wireguard而不设置全局路由，让用户能够自由决定哪些流量走飞连，最小化网络影响。

已在Linux测试正常。