### PR TITLE
feat: add route_mode (split/full) and vpn_disallowed_routes, port from TundraWork/corplink

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,12 @@ RUST_LOG=debug ./corplink-rs config.json
   "use_vpn_dns": false,
   // automatically setup system routes (default: true)
   // set to false if you want to manually configure routes
-  "auto_setup_routes": true
+  "auto_setup_routes": true,
+  // route mode: "split" (default) or "full"
+  // - split: use intranet routes from server (same as official split mode)
+  // - full:  use full-tunnel routes from server (0.0.0.0/0, ::/0)
+  //          often combined with "auto_setup_routes": false in container/gateway setups
+  "route_mode": "split"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ RUST_LOG=debug ./corplink-rs config.json
   // - full:  use full-tunnel routes from server
   //          often combined with "auto_setup_routes": false in container/gateway setups
   "route_mode": "split",
-  // optional: CIDR routes to exclude from AllowedIPs (and system routes).
-  // useful in full mode to punch holes for local LAN or the VPN peer IP itself
-  // to avoid routing loops that would otherwise black-hole all traffic.
+  // optional: list of CIDRs to carve out of AllowedIPs (and system routes).
+  // applied as CIDR subtraction: each entry is subtracted from every route
+  // returned by the server, so listing a smaller range like "10.68.0.0/16"
+  // still punches a hole even when the server returns a supernet like
+  // "0.0.0.0/0" (full-tunnel). useful for keeping local LAN traffic off the
+  // VPN, and for excluding the VPN peer endpoint IP to avoid a routing loop
+  // that would otherwise black-hole all traffic.
   "vpn_disallowed_routes": ["192.168.1.0/24"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -131,9 +131,13 @@ RUST_LOG=debug ./corplink-rs config.json
   "auto_setup_routes": true,
   // route mode: "split" (default) or "full"
   // - split: use intranet routes from server (same as official split mode)
-  // - full:  use full-tunnel routes from server (0.0.0.0/0, ::/0)
+  // - full:  use full-tunnel routes from server
   //          often combined with "auto_setup_routes": false in container/gateway setups
-  "route_mode": "split"
+  "route_mode": "split",
+  // optional: CIDR routes to exclude from AllowedIPs (and system routes).
+  // useful in full mode to punch holes for local LAN or the VPN peer IP itself
+  // to avoid routing loops that would otherwise black-hole all traffic.
+  "vpn_disallowed_routes": ["192.168.1.0/24"]
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -818,11 +818,34 @@ impl Client {
         let address6 = (!wg_info.ipv6.is_empty())
             .then_some(format!("{}/128", wg_info.ipv6))
             .unwrap_or("".into());
-        let allowed_ips = [
-            wg_info.setting.vpn_route_split,
-            wg_info.setting.v6_route_split.unwrap_or_default(),
-        ]
-        .concat();
+        let allowed_ips = match self.conf.route_mode.clone().unwrap_or_default() {
+            crate::config::RouteMode::Split => {
+                log::info!("route_mode = split");
+                [
+                    wg_info.setting.vpn_route_split,
+                    wg_info.setting.v6_route_split.unwrap_or_default(),
+                ]
+                .concat()
+            }
+            crate::config::RouteMode::Full => {
+                log::info!("route_mode = full");
+                let mut v4 = wg_info.setting.vpn_route_full;
+                let mut v6 = wg_info.setting.v6_route_full.unwrap_or_default();
+                if v4.is_empty() {
+                    log::warn!(
+                        "route_mode=full but vpn_route_full is empty, falling back to 0.0.0.0/0"
+                    );
+                    v4.push("0.0.0.0/0".to_string());
+                }
+                if v6.is_empty() {
+                    log::warn!(
+                        "route_mode=full but v6_route_full is empty, falling back to ::/0"
+                    );
+                    v6.push("::/0".to_string());
+                }
+                [v4, v6].concat()
+            }
+        };
         let auto_setup_routes = self.conf.auto_setup_routes.unwrap_or(true);
         let routes = if auto_setup_routes {
             allowed_ips.clone()
@@ -871,7 +894,13 @@ impl Client {
         let mut m = Map::new();
         m.insert("ip".to_string(), json!(conf.address));
         m.insert("public_key".to_string(), json!(conf.public_key));
-        m.insert("mode".to_string(), json!("Split"));
+        m.insert(
+            "mode".to_string(),
+            json!(match self.conf.route_mode.clone().unwrap_or_default() {
+                crate::config::RouteMode::Split => "Split",
+                crate::config::RouteMode::Full => "Full",
+            }),
+        );
         m.insert("type".to_string(), json!("100"));
 
         let resp = self
@@ -891,7 +920,13 @@ impl Client {
         let mut m = Map::new();
         m.insert("ip".to_string(), json!(wg_conf.address));
         m.insert("public_key".to_string(), json!(wg_conf.public_key));
-        m.insert("mode".to_string(), json!("Split"));
+        m.insert(
+            "mode".to_string(),
+            json!(match self.conf.route_mode.clone().unwrap_or_default() {
+                crate::config::RouteMode::Split => "Split",
+                crate::config::RouteMode::Full => "Full",
+            }),
+        );
         m.insert("type".to_string(), json!("101"));
         let resp = self
             .request::<Map<String, Value>>(ApiName::DisconnectVPN, Some(m))

--- a/src/client.rs
+++ b/src/client.rs
@@ -851,17 +851,66 @@ impl Client {
             }
         };
 
-        // Filter out user-configured disallowed routes to avoid routing loops
-        // (e.g. peer VPN server IP, local LAN segments). Matches by exact CIDR string.
+        // Carve user-specified CIDRs out of allowed_ips. This removes any IPs in
+        // vpn_disallowed_routes from the VPN's AllowedIPs (and the system routes
+        // derived from them), which is the standard way to avoid routing loops in
+        // full-tunnel mode — e.g. listing the local LAN or a CIDR covering the
+        // VPN peer endpoint so their packets don't get captured by the tunnel.
+        //
+        // Semantics: CIDR subtraction. An entry like "10.68.0.0/16" carves that
+        // whole range out of each allowed_ip, even when allowed_ip is a larger
+        // supernet such as "0.0.0.0/0" — which expands to a minimal set of
+        // smaller CIDRs covering "allowed minus disallowed".
         if let Some(disallowed) = self.conf.vpn_disallowed_routes.as_ref() {
             if !disallowed.is_empty() {
                 let before = allowed_ips.len();
-                allowed_ips.retain(|r| !disallowed.contains(r));
+                for d in disallowed {
+                    let mut carved = Vec::with_capacity(allowed_ips.len());
+                    for a in &allowed_ips {
+                        carved.extend(crate::utils::subtract_cidr_from_cidr(a, d));
+                    }
+                    allowed_ips = carved;
+                }
                 log::info!(
-                    "vpn_disallowed_routes applied: {} -> {} entries (removed: {:?})",
+                    "vpn_disallowed_routes applied: {} -> {} entries (carved: {:?})",
                     before,
                     allowed_ips.len(),
                     disallowed
+                );
+            }
+        }
+
+        // Auto-carve the VPN peer endpoint IP out of allowed_ips. In full-tunnel mode
+        // the server typically returns 0.0.0.0/0, which would match the outer UDP
+        // packets going to the peer itself, producing a routing loop (black hole).
+        // Mirrors wg-quick's behavior of excluding the endpoint from routes. No-op
+        // when the peer IP isn't covered by any allowed_ip (e.g. split mode).
+        match vpn.ip.parse::<std::net::IpAddr>() {
+            Ok(peer_ip) => {
+                let peer_cidr = match peer_ip {
+                    std::net::IpAddr::V4(_) => format!("{}/32", peer_ip),
+                    std::net::IpAddr::V6(_) => format!("{}/128", peer_ip),
+                };
+                let before = allowed_ips.len();
+                let mut carved = Vec::with_capacity(allowed_ips.len());
+                for a in &allowed_ips {
+                    carved.extend(crate::utils::subtract_cidr_from_cidr(a, &peer_cidr));
+                }
+                if carved.len() != before {
+                    log::info!(
+                        "auto-carved peer endpoint {} out of allowed_ips: {} -> {} entries",
+                        peer_cidr,
+                        before,
+                        carved.len()
+                    );
+                }
+                allowed_ips = carved;
+            }
+            Err(e) => {
+                log::warn!(
+                    "could not parse vpn.ip {:?} as IP, skipping peer-IP carve-out: {}",
+                    vpn.ip,
+                    e
                 );
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -831,6 +831,16 @@ impl Client {
                 log::info!("route_mode = full");
                 let mut v4 = wg_info.setting.vpn_route_full;
                 let mut v6 = wg_info.setting.v6_route_full.unwrap_or_default();
+                log::info!(
+                    "route_mode=full, server returned vpn_route_full ({} entries): {:?}",
+                    v4.len(),
+                    v4
+                );
+                log::info!(
+                    "route_mode=full, server returned v6_route_full ({} entries): {:?}",
+                    v6.len(),
+                    v6
+                );
                 if v4.is_empty() {
                     log::warn!(
                         "route_mode=full but vpn_route_full is empty, falling back to 0.0.0.0/0"
@@ -843,7 +853,13 @@ impl Client {
                     );
                     v6.push("::/0".to_string());
                 }
-                [v4, v6].concat()
+                let merged = [v4, v6].concat();
+                log::info!(
+                    "route_mode=full, merged allowed_ips ({} entries): {:?}",
+                    merged.len(),
+                    merged
+                );
+                merged
             }
         };
         let auto_setup_routes = self.conf.auto_setup_routes.unwrap_or(true);

--- a/src/client.rs
+++ b/src/client.rs
@@ -818,7 +818,7 @@ impl Client {
         let address6 = (!wg_info.ipv6.is_empty())
             .then_some(format!("{}/128", wg_info.ipv6))
             .unwrap_or("".into());
-        let allowed_ips = match self.conf.route_mode.clone().unwrap_or_default() {
+        let mut allowed_ips = match self.conf.route_mode.clone().unwrap_or_default() {
             crate::config::RouteMode::Split => {
                 log::info!("route_mode = split");
                 [
@@ -829,8 +829,8 @@ impl Client {
             }
             crate::config::RouteMode::Full => {
                 log::info!("route_mode = full");
-                let mut v4 = wg_info.setting.vpn_route_full;
-                let mut v6 = wg_info.setting.v6_route_full.unwrap_or_default();
+                let v4 = wg_info.setting.vpn_route_full;
+                let v6 = wg_info.setting.v6_route_full.unwrap_or_default();
                 log::info!(
                     "route_mode=full, server returned vpn_route_full ({} entries): {:?}",
                     v4.len(),
@@ -841,27 +841,35 @@ impl Client {
                     v6.len(),
                     v6
                 );
-                if v4.is_empty() {
-                    log::warn!(
-                        "route_mode=full but vpn_route_full is empty, falling back to 0.0.0.0/0"
+                if v4.is_empty() && v6.is_empty() {
+                    bail!(
+                        "route_mode=full but server returned no routes (vpn_route_full / v6_route_full both empty); \
+                         refuse to fall back to 0.0.0.0/0 to avoid peer-IP routing loop that blocks all traffic"
                     );
-                    v4.push("0.0.0.0/0".to_string());
                 }
-                if v6.is_empty() {
-                    log::warn!(
-                        "route_mode=full but v6_route_full is empty, falling back to ::/0"
-                    );
-                    v6.push("::/0".to_string());
-                }
-                let merged = [v4, v6].concat();
-                log::info!(
-                    "route_mode=full, merged allowed_ips ({} entries): {:?}",
-                    merged.len(),
-                    merged
-                );
-                merged
+                [v4, v6].concat()
             }
         };
+
+        // Filter out user-configured disallowed routes to avoid routing loops
+        // (e.g. peer VPN server IP, local LAN segments). Matches by exact CIDR string.
+        if let Some(disallowed) = self.conf.vpn_disallowed_routes.as_ref() {
+            if !disallowed.is_empty() {
+                let before = allowed_ips.len();
+                allowed_ips.retain(|r| !disallowed.contains(r));
+                log::info!(
+                    "vpn_disallowed_routes applied: {} -> {} entries (removed: {:?})",
+                    before,
+                    allowed_ips.len(),
+                    disallowed
+                );
+            }
+        }
+        log::info!(
+            "final allowed_ips ({} entries): {:?}",
+            allowed_ips.len(),
+            allowed_ips
+        );
         let auto_setup_routes = self.conf.auto_setup_routes.unwrap_or(true);
         let routes = if auto_setup_routes {
             allowed_ips.clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,25 @@ pub const PLATFORM_AAD: &str = "aad";
 pub const STRATEGY_LATENCY: &str = "latency";
 pub const STRATEGY_DEFAULT: &str = "default";
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum RouteMode {
+    /// Only intranet routes returned by the server (mimics official split mode).
+    #[default]
+    Split,
+    /// Full-tunnel routes from the server (typically 0.0.0.0/0, ::/0).
+    Full,
+}
+
+impl fmt::Display for RouteMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RouteMode::Split => write!(f, "split"),
+            RouteMode::Full => write!(f, "full"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
     pub company_name: String,
@@ -48,6 +67,8 @@ pub struct Config {
     pub vpn_select_strategy: Option<String>,
     pub use_vpn_dns: Option<bool>,
     pub auto_setup_routes: Option<bool>,
+    /// "split" (default) or "full". Selects which route list from the server to apply.
+    pub route_mode: Option<RouteMode>,
 }
 
 impl fmt::Display for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,10 @@ pub struct Config {
     pub auto_setup_routes: Option<bool>,
     /// "split" (default) or "full". Selects which route list from the server to apply.
     pub route_mode: Option<RouteMode>,
+    /// Optional list of CIDR routes to exclude from AllowedIPs / system routes.
+    /// Useful in full mode to punch holes for local LAN or the VPN peer IP itself,
+    /// avoiding routing loops (e.g. 192.168.1.0/24, 10.0.0.5/32).
+    pub vpn_disallowed_routes: Option<Vec<String>>,
 }
 
 impl fmt::Display for Config {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use std::io::{self, BufRead};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -50,4 +51,280 @@ pub fn b64_decode_to_hex(s: &str) -> Result<String> {
         hex.push_str(format!("{c:02x}").as_str());
     }
     Ok(hex)
+}
+
+/// Returns a list of CIDR strings covering all addresses in `outer` except those in `inner`.
+///
+/// - Disjoint (no overlap) → `[outer]` unchanged.
+/// - `inner` fully covers `outer` → `[]` (everything is removed).
+/// - `outer` strictly contains `inner` → a minimal set of CIDRs whose union is
+///   exactly `outer \ inner` (one CIDR per bit of prefix difference).
+/// - Address-family mismatch or unparseable input → `[outer]` unchanged
+///   (conservative: never silently drop routes).
+///
+/// Used by the VPN client to carve user-specified ranges
+/// (`vpn_disallowed_routes`, e.g. local LAN) out of the server-supplied AllowedIPs
+/// (e.g. `0.0.0.0/0` in full-tunnel mode).
+pub fn subtract_cidr_from_cidr(outer: &str, inner: &str) -> Vec<String> {
+    let Some((outer_base, outer_prefix)) = parse_cidr(outer) else {
+        return vec![outer.to_string()];
+    };
+    let Some((inner_base, inner_prefix)) = parse_cidr(inner) else {
+        return vec![outer.to_string()];
+    };
+    if !same_family(outer_base, inner_base) {
+        return vec![outer.to_string()];
+    }
+    // inner covers outer (inner prefix is shorter or equal and contains outer's base)
+    if inner_prefix <= outer_prefix
+        && cidr_contains_ip(inner_base, inner_prefix, outer_base)
+    {
+        return Vec::new();
+    }
+    // outer doesn't contain inner → disjoint
+    if !cidr_contains_ip(outer_base, outer_prefix, inner_base) {
+        return vec![outer.to_string()];
+    }
+    // outer strictly contains inner, carve by recursive bisection
+    let host_bits = host_bit_count(outer_base);
+    carve_recursive(outer_base, outer_prefix, host_bits, inner_base, inner_prefix)
+}
+
+fn parse_cidr(cidr: &str) -> Option<(IpAddr, u8)> {
+    let (ip_s, prefix_s) = cidr.split_once('/')?;
+    let ip: IpAddr = ip_s.parse().ok()?;
+    let prefix: u8 = prefix_s.parse().ok()?;
+    if prefix > host_bit_count(ip) {
+        return None;
+    }
+    Some((canonicalize(ip, prefix), prefix))
+}
+
+fn host_bit_count(ip: IpAddr) -> u8 {
+    match ip {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    }
+}
+
+fn same_family(a: IpAddr, b: IpAddr) -> bool {
+    matches!(
+        (a, b),
+        (IpAddr::V4(_), IpAddr::V4(_)) | (IpAddr::V6(_), IpAddr::V6(_))
+    )
+}
+
+fn mask_v4(prefix: u8) -> u32 {
+    if prefix == 0 { 0 } else { u32::MAX << (32 - prefix) }
+}
+
+fn mask_v6(prefix: u8) -> u128 {
+    if prefix == 0 { 0 } else { u128::MAX << (128 - prefix) }
+}
+
+fn canonicalize(ip: IpAddr, prefix: u8) -> IpAddr {
+    match ip {
+        IpAddr::V4(a) => IpAddr::V4(Ipv4Addr::from(u32::from(a) & mask_v4(prefix))),
+        IpAddr::V6(a) => IpAddr::V6(Ipv6Addr::from(u128::from(a) & mask_v6(prefix))),
+    }
+}
+
+fn cidr_contains_ip(base: IpAddr, prefix: u8, ip: IpAddr) -> bool {
+    match (base, ip) {
+        (IpAddr::V4(b), IpAddr::V4(a)) => {
+            let m = mask_v4(prefix);
+            (u32::from(b) & m) == (u32::from(a) & m)
+        }
+        (IpAddr::V6(b), IpAddr::V6(a)) => {
+            let m = mask_v6(prefix);
+            (u128::from(b) & m) == (u128::from(a) & m)
+        }
+        _ => false,
+    }
+}
+
+fn split_half(base: IpAddr, prefix: u8) -> (IpAddr, IpAddr) {
+    match base {
+        IpAddr::V4(b) => {
+            let bu = u32::from(b);
+            let bit = 1u32 << (31 - prefix);
+            (IpAddr::V4(Ipv4Addr::from(bu)), IpAddr::V4(Ipv4Addr::from(bu | bit)))
+        }
+        IpAddr::V6(b) => {
+            let bu = u128::from(b);
+            let bit = 1u128 << (127 - prefix);
+            (IpAddr::V6(Ipv6Addr::from(bu)), IpAddr::V6(Ipv6Addr::from(bu | bit)))
+        }
+    }
+}
+
+fn carve_recursive(
+    outer_base: IpAddr,
+    outer_prefix: u8,
+    host_bits: u8,
+    inner_base: IpAddr,
+    inner_prefix: u8,
+) -> Vec<String> {
+    if outer_prefix == inner_prefix {
+        // caller guaranteed containment ⇒ outer == inner
+        return Vec::new();
+    }
+    debug_assert!(outer_prefix < inner_prefix && outer_prefix < host_bits);
+    let new_prefix = outer_prefix + 1;
+    let (lower, upper) = split_half(outer_base, outer_prefix);
+    let (containing, sibling) = if cidr_contains_ip(lower, new_prefix, inner_base) {
+        (lower, upper)
+    } else {
+        (upper, lower)
+    };
+    let mut out = Vec::with_capacity((inner_prefix - outer_prefix) as usize);
+    out.push(format!("{}/{}", sibling, new_prefix));
+    out.extend(carve_recursive(
+        containing,
+        new_prefix,
+        host_bits,
+        inner_base,
+        inner_prefix,
+    ));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sorted(mut v: Vec<String>) -> Vec<String> {
+        v.sort();
+        v
+    }
+
+    fn cidr_contains_addr(cidr: &str, addr: IpAddr) -> bool {
+        let (base_s, prefix_s) = cidr.split_once('/').expect("bad CIDR in test helper");
+        let base: IpAddr = base_s.parse().expect("bad base in test helper");
+        let prefix: u8 = prefix_s.parse().expect("bad prefix in test helper");
+        match (base, addr) {
+            (IpAddr::V4(b), IpAddr::V4(a)) => {
+                let mask = if prefix == 0 { 0 } else { u32::MAX << (32 - prefix) };
+                (u32::from(b) & mask) == (u32::from(a) & mask)
+            }
+            (IpAddr::V6(b), IpAddr::V6(a)) => {
+                let mask = if prefix == 0 { 0 } else { u128::MAX << (128 - prefix) };
+                (u128::from(b) & mask) == (u128::from(a) & mask)
+            }
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn subtract_disjoint_returns_outer_unchanged() {
+        let out = subtract_cidr_from_cidr("10.0.0.0/24", "192.168.0.0/16");
+        assert_eq!(out, vec!["10.0.0.0/24"]);
+    }
+
+    #[test]
+    fn subtract_inner_equal_to_outer_returns_empty() {
+        let out = subtract_cidr_from_cidr("10.0.0.0/24", "10.0.0.0/24");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn subtract_inner_covers_outer_returns_empty() {
+        // inner /16 swallows outer /24
+        let out = subtract_cidr_from_cidr("10.0.5.0/24", "10.0.0.0/16");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn subtract_outer_covers_inner_produces_expected_complement() {
+        // 10.0.0.0/16 minus 10.0.5.0/24 = 8 CIDRs (one per split level from /16 to /24).
+        let out = sorted(subtract_cidr_from_cidr("10.0.0.0/16", "10.0.5.0/24"));
+        let expected = sorted(vec![
+            "10.0.0.0/22".into(),
+            "10.0.4.0/24".into(),
+            "10.0.6.0/23".into(),
+            "10.0.8.0/21".into(),
+            "10.0.16.0/20".into(),
+            "10.0.32.0/19".into(),
+            "10.0.64.0/18".into(),
+            "10.0.128.0/17".into(),
+        ]);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn subtract_family_mismatch_returns_outer_unchanged() {
+        let out = subtract_cidr_from_cidr("10.0.0.0/24", "::/0");
+        assert_eq!(out, vec!["10.0.0.0/24"]);
+        let out = subtract_cidr_from_cidr("2001:db8::/32", "10.0.0.0/8");
+        assert_eq!(out, vec!["2001:db8::/32"]);
+    }
+
+    #[test]
+    fn subtract_unparseable_returns_outer_unchanged() {
+        assert_eq!(
+            subtract_cidr_from_cidr("not-a-cidr", "10.0.0.0/8"),
+            vec!["not-a-cidr"]
+        );
+        assert_eq!(
+            subtract_cidr_from_cidr("10.0.0.0/8", "not-a-cidr"),
+            vec!["10.0.0.0/8"]
+        );
+        assert_eq!(
+            subtract_cidr_from_cidr("10.0.0.0/99", "10.0.0.0/24"),
+            vec!["10.0.0.0/99"]
+        );
+    }
+
+    #[test]
+    fn subtract_single_host_from_default_route_yields_32_cidrs_not_covering_host() {
+        // /32 subtraction is a special case of general CIDR subtraction.
+        let out = subtract_cidr_from_cidr("0.0.0.0/0", "1.2.3.4/32");
+        assert_eq!(out.len(), 32);
+        let host: IpAddr = "1.2.3.4".parse().unwrap();
+        for cidr in &out {
+            assert!(!cidr_contains_addr(cidr, host), "{} should not cover 1.2.3.4", cidr);
+        }
+    }
+
+    #[test]
+    fn subtract_lan_cidr_from_default_route_yields_16_cidrs_not_covering_any_lan_ip() {
+        // The motivating scenario: 0.0.0.0/0 - 10.68.0.0/16 in full-tunnel mode.
+        // Going /0 down to /16 is 16 split levels, so 16 complement CIDRs.
+        let out = subtract_cidr_from_cidr("0.0.0.0/0", "10.68.0.0/16");
+        assert_eq!(out.len(), 16);
+        // Sample IPs that must NOT be covered by any complement CIDR:
+        for ip_s in ["10.68.0.1", "10.68.40.10", "10.68.255.255"] {
+            let ip: IpAddr = ip_s.parse().unwrap();
+            for cidr in &out {
+                assert!(
+                    !cidr_contains_addr(cidr, ip),
+                    "complement CIDR {} should not cover LAN IP {}",
+                    cidr,
+                    ip_s
+                );
+            }
+        }
+        // And an IP outside 10.68.0.0/16 must be covered by exactly one complement CIDR:
+        let outside: IpAddr = "8.8.8.8".parse().unwrap();
+        let covers = out
+            .iter()
+            .filter(|c| cidr_contains_addr(c, outside))
+            .count();
+        assert_eq!(covers, 1);
+    }
+
+    #[test]
+    fn subtract_ipv6_default_minus_host_yields_128_cidrs() {
+        let out = subtract_cidr_from_cidr("::/0", "2001:db8::1/128");
+        assert_eq!(out.len(), 128);
+    }
+
+    #[test]
+    fn subtract_non_canonical_inner_is_normalized() {
+        // 10.0.5.7/24 is not canonical; mask-aligned form is 10.0.5.0/24.
+        // Subtraction should treat it as the canonical form, not as a literal.
+        let out = sorted(subtract_cidr_from_cidr("10.0.0.0/16", "10.0.5.7/24"));
+        let expected = sorted(subtract_cidr_from_cidr("10.0.0.0/16", "10.0.5.0/24"));
+        assert_eq!(out, expected);
+    }
 }


### PR DESCRIPTION
## Summary

This PR ports the `routing_mode` (split / full) feature from [TundraWork/corplink](https://github.com/TundraWork/corplink) into this project, addressing long-standing requests such as #48 for full-tunnel support.

Reference implementation used for the route selection logic:
https://github.com/TundraWork/corplink/blob/cf6f640cf2771f66d06d65549028f73588031b7d/src/client.rs#L760-L764

### What's added

1. **`route_mode: Option<RouteMode>` config (values: `split` | `full`, default `split`)**
   - `split` — use the server-returned `vpn_route_split` (current behavior, unchanged).
   - `full`  — use the server-returned `vpn_route_full` (official-client "full-tunnel" mode).
   - The selected route list is applied to both WireGuard `AllowedIPs` and, when `auto_setup_routes=true`, the system routing table.

2. **`vpn_disallowed_routes: Option<Vec<String>>` config (CIDR subtraction)**
   - Carves user-specified CIDR ranges out of the server-returned route list.
   - **Semantics: CIDR subtraction**, not exact-string matching. Each entry is recursively subtracted from every `allowed_ip`, so `"10.68.0.0/16"` still has an effect even when the server returned a supernet like `"0.0.0.0/0"` — the supernet is expanded into the minimal set of smaller CIDRs covering "allowed \ disallowed".
   - Typical uses: keep local LAN off the tunnel, carve out `172.16.0.0/12` so docker bridges keep their connected routes, etc.

3. **Auto-carve the VPN peer endpoint IP out of `allowed_ips`**
   - Standard `wg-quick` behavior. In full-tunnel mode the server's own public IP would otherwise be captured by the `0.0.0.0/0` route on the wg interface, producing a routing loop that black-holes all traffic (handshake packets meant to reach the VPN server get routed back into the tunnel instead of out through the real default gateway).
   - No-op when the peer IP is not covered by any `allowed_ip` (split mode, typical case).
   - Means users no longer need to list the peer IP manually in `vpn_disallowed_routes` to avoid the routing loop.

4. **`mode` field reported to server**
   - In `connect_vpn` / `report_vpn_status` / `disconnect_vpn`, the `mode` JSON field now reflects the selected `route_mode` (`"Split"` / `"Full"`) instead of being hardcoded.

5. **Debug logs** for full mode: server-returned `vpn_route_full` / `v6_route_full`, `vpn_disallowed_routes` carve counts, auto peer-IP carve, and final `allowed_ips`.

### Design notes

- Full mode **does not** force-fallback to `0.0.0.0/0` when the server returns empty routes. Silently doing so would mask the underlying issue and, absent a peer-IP carve-out, black-hole all traffic. Instead, an empty response aborts with a clear error.
- The auto peer-IP carve-out makes `route_mode=full` safe by default on all platforms (mirrors `wg-quick`); users no longer need to hand-list the peer IP to avoid the routing loop.
- `vpn_disallowed_routes` uses **CIDR subtraction**. An entry like `"10.68.0.0/16"` has an effect even when the server returned a larger supernet such as `"0.0.0.0/0"` (the bisection algorithm expands `/0 - /16` into 16 smaller CIDRs). This is a behavior change from the previous exact-string match semantics; under the old behavior such an entry was a silent no-op in full mode.
- Split mode preserves exactly the pre-existing behavior; existing configs without `route_mode` are unaffected.
- All new fields are optional and ignored when absent, so the change is fully backwards compatible.

### Relation to #81

This builds on top of the `auto_setup_routes` flag introduced in #81 — users can still turn off automatic route setup and manage routes externally (e.g. in a Docker/gateway deployment running full tunnel).

### Config example

```jsonc
{
  "auto_setup_routes": true,
  "route_mode": "full",
  // Carve these ranges out of the full-tunnel route list.
  // The peer endpoint IP is auto-carved separately; no need to list it here.
  "vpn_disallowed_routes": [
    "172.16.0.0/12",   // leave docker bridges alone
    "192.168.1.0/24"   // local LAN
  ]
}
```

## Test plan

- [x] `cargo build --release` clean (pre-existing dead_code warnings only).
- [x] `cargo test` — 14 tests pass, including 10 new unit tests for the CIDR-subtraction primitive `utils::subtract_cidr_from_cidr`: disjoint / inner-covers-outer / outer-covers-inner / exact equality / family mismatch / unparseable input / non-canonical inner base / single-host `/32` exclusion from `/0` (→ 32 complement CIDRs) / `0.0.0.0/0 - 10.68.0.0/16` → 16 complement CIDRs / IPv6 `::/0 - /128` → 128 CIDRs.
- [x] Runtime test: split mode with existing config — unchanged behavior.
- [x] Runtime test: full mode with server returning `["0.0.0.0/1", "128.0.0.0/1", <intranet/32>]` — peer IP auto-carved, routes installed cleanly (verified with `ip route get <peer_ip>` → original default gateway; `ip route get <intranet>` → `dev corplink`).
- [x] Runtime test: full mode + `vpn_disallowed_routes` — specified CIDRs are excluded from AllowedIPs and system routes; `ip route show` confirms no `<disallowed> dev corplink` entry. Also confirmed useful for sidestepping route-install conflicts with pre-existing docker bridge networks (EEXIST on `172.x.0.0/16`).