### PR TITLE
feat(login): poll tps auth token instead of blocking on stdin

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -277,6 +277,42 @@ impl Client {
         }
     }
 
+    /// Poll `check_tps_token` until the user completes third-party auth, or timeout.
+    ///
+    /// Replaces the old `press enter if you finish auth` / stdin-blocking flow, which
+    /// (a) requires an attached TTY — in containers without one, stdin returns EOF
+    /// immediately and the check fires before the user could possibly authorize,
+    /// and (b) is tedious even with a TTY. Standard OAuth device-flow pattern: show
+    /// the URL, then the client polls the "has the user confirmed yet?" endpoint.
+    async fn wait_for_tps_auth(&mut self, token: &String) -> Result<String> {
+        const POLL_INTERVAL: Duration = Duration::from_secs(3);
+        const POLL_TIMEOUT: Duration = Duration::from_secs(300);
+        let deadline = tokio::time::Instant::now() + POLL_TIMEOUT;
+        let mut attempts: u32 = 0;
+        loop {
+            attempts += 1;
+            match self.check_tps_token(token).await {
+                Ok(url) => {
+                    log::info!("third-party auth completed after {attempts} attempt(s)");
+                    return Ok(url);
+                }
+                Err(e) => {
+                    let now = tokio::time::Instant::now();
+                    if now >= deadline {
+                        return Err(e.context(format!(
+                            "third-party auth not completed within {}s ({} polls)",
+                            POLL_TIMEOUT.as_secs(),
+                            attempts
+                        )));
+                    }
+                    log::debug!("tps token check attempt {attempts} not ready: {e}");
+                    let remaining = deadline - now;
+                    tokio::time::sleep(POLL_INTERVAL.min(remaining)).await;
+                }
+            }
+        }
+    }
+
     async fn get_otp_uri_from_tps(
         &mut self,
         method: &str,
@@ -291,10 +327,10 @@ impl Client {
         }
         match method {
             PLATFORM_LARK | PLATFORM_OIDC => {
-                log::info!("press enter if you finish auth");
-                let stdin = io::stdin();
-                stdin.lines().next();
-                self.check_tps_token(token).await
+                log::info!(
+                    "waiting for third-party auth (polling every 3s, up to 5min)..."
+                );
+                self.wait_for_tps_auth(token).await
             }
             _ => {
                 // TODO: add all tps login support


### PR DESCRIPTION
## Summary

Removes the `press enter if you finish auth` / stdin-blocking step from the Lark / OIDC third-party login flow, replacing it with periodic polling of the token-check endpoint (standard OAuth device-flow pattern).

## Problem

Two issues with the current flow in `get_otp_uri_from_tps`:

1. **Broken in no-TTY environments (containers, systemd, `nohup`, etc.).**
   `io::stdin().lines().next()` returns `None` immediately when stdin has no TTY — the intended "wait for user to finish auth" is effectively zero. `check_tps_token` then fires before the user could possibly authorize on Feishu, and login fails with `User is not logged in`. The misleading error hides that the client never actually waited.

2. **Tedious with a TTY.** Even interactively, the user has to come back and press Enter after authorizing. This precludes running corplink-rs as a fire-and-forget systemd service or docker container; every restart requires a human at the keyboard.

## Change

`get_otp_uri_from_tps` → new helper `wait_for_tps_auth` that polls `check_tps_token` on a 3s interval up to a 5min deadline:

- Show the auth URL (unchanged).
- Poll every 3s. On success → proceed.
- On timeout → bail with a clear error: `third-party auth not completed within 300s (N polls)` and the last server-side message as context.

Defaults (3s / 300s) cover Lark's typical 10-30s user turnaround with margin. Not exposed as config for now; can be promoted later if anyone needs custom values.

## Behavior

| Scenario | Before | After |
|---|---|---|
| TTY, user authorizes + presses Enter | works | works (no Enter needed) |
| TTY, user authorizes but doesn't press Enter | hangs forever | auto-proceeds within ~3s |
| No TTY (container / service) | fails immediately with "User is not logged in" | polls correctly, works as intended |
| User takes > 5min | hangs forever | bails with timeout error |

## Test plan

- [x] `cargo build --release` clean (pre-existing dead_code warnings only).
- [x] `cargo test` — 14 tests pass (no new tests; polling logic has no side-effect-free unit-testable surface without mocking the Corplink HTTP API).
- [x] Runtime test in a docker container (no TTY): login with `platform: null`, Lark flow kicks in, URL printed, authorize on Feishu, client auto-proceeds within one poll interval. Previously this path failed with `User is not logged in` immediately.
- [ ] Long runtime: confirm 5-minute timeout fires cleanly when user never authorizes (not tested — don't want to wait, and the code path is trivial).

## Related

Built on top of #82 (route_mode + vpn_disallowed_routes), but independent. Both are aimed at making `corplink-rs` usable in a containerized, long-running deployment without interactive hand-holding.