### PR TITLE
fix: improve lark login, QR code, and Windows setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,8 @@ jobs:
         run: |
           Move-Item -Path "target/release/corplink-rs.exe" -Destination "."
           Move-Item -Path "config/config.json" -Destination "."
-          Compress-Archive -Path corplink-rs.exe,config.json -Destination corplink-rs-${{ github.ref_name }}-windows.zip
+          Copy-Item -Path "scripts/setup.ps1" -Destination "."
+          Compress-Archive -Path corplink-rs.exe,config.json,setup.ps1 -Destination corplink-rs-${{ github.ref_name }}-windows.zip
       - name: upload package to artifact
         uses: actions/upload-artifact@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 # libwg
 libwg/libwg.a
 libwg/libwg.h
+
+# release artifacts
+/release/
+*.zip

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ systemctl start corplink-rs@test.service
 
 ### 快速开始（推荐使用预编译版本）
 
-1. 从 [Releases](https://github.com/Ben8368/corplink-rs/releases) 下载 `corplink-rs-*-windows.zip`
+1. 从 [Releases](https://github.com/PinkD/corplink-rs/releases) 下载 `corplink-rs-*-windows.zip`
 2. 解压到任意目录
 3. 运行 `setup.ps1` 自动获取 `wintun.dll`：
 
@@ -115,7 +115,6 @@ $env:RUST_LOG="debug"; .\corplink-rs.exe config.json
 
 - **wintun.dll 找不到**：运行 `setup.ps1` 或手动下载放入同目录
 - **配置文件 JSON 不支持注释**：示例中的 `// comment` 需要删除
-- **Windows 上的 `conf_dir`**：`/etc/wireguard` 是 Linux 路径，Windows 会忽略此配置项
 - **路由未生效**：检查是否以管理员运行，关闭其他 VPN 软件避免路由冲突
 
 ## macos 特殊说明

--- a/README.md
+++ b/README.md
@@ -34,7 +34,25 @@ mv target/release/corplink-rs /usr/bin/
 
 ### windows
 
-参考 [#34](https://github.com/PinkD/corplink-rs/issues/34)
+**前提**: 需要 Go (≥1.22)、GCC (MinGW-w64)、make、Rust (GNU 工具链)。
+
+安装工具链后，在 **PowerShell** 中执行：
+
+```powershell
+# 1. 构建 libwg（生成 libwg.a + libwg.h）
+cd libwg
+.\build.ps1
+
+# 2. 构建 Rust 项目
+cd ..
+rustup toolchain install stable-gnu
+rustup default stable-x86_64-pc-windows-gnu
+cargo build --release
+```
+
+> 编译的 `build.ps1` 会调用 `make libwg`，该目标会以 `CGO_ENABLED=1` 编译 Go 代码。
+> MinGW GCC 需要在 PATH 中，且 make 需要支持 bash 风格环境变量语法。
+> 也可在 MSYS2 UCRT64 环境中执行 `./build.sh`（同样需要 Go + GCC）。
 
 # 用法
 
@@ -55,9 +73,50 @@ systemctl enable corplink-rs.service
 systemctl start corplink-rs@test.service
 ```
 
-## windows 特殊说明
+## windows 使用说明
 
-windows 中启动 `wg-go` 需要 [wintun](6) 支持，请到官网下载，并将 `wintun.dll` 与 `corplink-rs` 放到同一目录下(或者环境变量下)
+### 快速开始（推荐使用预编译版本）
+
+1. 从 [Releases](https://github.com/Ben8368/corplink-rs/releases) 下载 `corplink-rs-*-windows.zip`
+2. 解压到任意目录
+3. 运行 `setup.ps1` 自动获取 `wintun.dll`：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File setup.ps1
+```
+
+4. 编辑 `config.json`，填入公司代码和登录信息（见下方配置文件实例）
+5. 以**管理员身份**打开 PowerShell，运行：
+
+```powershell
+.\corplink-rs.exe config.json
+
+# 调试模式
+$env:RUST_LOG="debug"; .\corplink-rs.exe config.json
+```
+
+### wintun.dll 说明
+
+`corplink-rs` 依赖 [Wintun][6] 虚拟网卡驱动来创建 WireGuard 隧道。由于 Wintun 的许可证要求用户从[官网][6]直接获取，我们无法在 release 包中附带该文件。
+
+`setup.ps1` 脚本会自动从 `wintun.net` 下载并解压 `amd64` 版本的 `wintun.dll` 到当前目录。
+
+手动获取：访问 [wintun.net][6]，下载 zip 包，将 `bin/amd64/wintun.dll` 复制到 `corplink-rs.exe` 所在目录。
+
+### 管理员权限
+
+程序需要管理员权限，原因：
+- `wg-go` 需要创建 TUN 虚拟网卡
+- 配置系统路由表（自动添加 VPN 路由）
+
+如果运行时提示 `please run as administrator`，右键 PowerShell 选择"以管理员身份运行"。
+
+### 常见问题
+
+- **wintun.dll 找不到**：运行 `setup.ps1` 或手动下载放入同目录
+- **配置文件 JSON 不支持注释**：示例中的 `// comment` 需要删除
+- **Windows 上的 `conf_dir`**：`/etc/wireguard` 是 Linux 路径，Windows 会忽略此配置项
+- **路由未生效**：检查是否以管理员运行，关闭其他 VPN 软件避免路由冲突
 
 ## macos 特殊说明
 

--- a/config/config.json
+++ b/config/config.json
@@ -2,8 +2,5 @@
     "company_name": "company code name",
     "username": "your_name",
     "password": "your_pass",
-    // will generate corplink.conf
-    "conf_name": "corplink",
-    // will generate conf in /etc/wireguard
-    "conf_dir": "/etc/wireguard"
+    "platform": "feilian"
 }

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,71 @@
+# setup.ps1 — corplink-rs Windows 环境准备
+# 自动下载 wintun.dll 到当前目录
+# 用法: powershell -ExecutionPolicy Bypass -File setup.ps1
+
+$ErrorActionPreference = "Stop"
+
+$WintunVersion = "0.14.1"
+$WintunUrl = "https://www.wintun.net/builds/wintun-$WintunVersion.zip"
+$ZipFile = "wintun-$WintunVersion.zip"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+Write-Host "corplink-rs Windows setup" -ForegroundColor Cyan
+Write-Host "========================" -ForegroundColor Cyan
+
+# 检查 wintun.dll 是否已存在
+if (Test-Path "$ScriptDir\wintun.dll") {
+    $existing = Get-Item "$ScriptDir\wintun.dll"
+    Write-Host "[OK] wintun.dll 已存在 ($($existing.VersionInfo.FileVersion))，跳过下载" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "接下来:" -ForegroundColor Yellow
+    Write-Host "  1. 编辑 config.json 填入你的公司代码和账号信息"
+    Write-Host "  2. 以管理员身份运行: .\corplink-rs.exe config.json"
+    exit 0
+}
+
+Write-Host "[1/3] 下载 wintun.dll (v$WintunVersion) ..." -ForegroundColor Yellow
+Write-Host "        $WintunUrl"
+
+try {
+    Invoke-WebRequest -Uri $WintunUrl -OutFile "$env:TEMP\$ZipFile" -UseBasicParsing
+} catch {
+    Write-Host "[ERROR] 下载失败: $_" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "请手动下载:" -ForegroundColor Yellow
+    Write-Host "  1. 打开 https://www.wintun.net/"
+    Write-Host "  2. 下载 wintun-$WintunVersion.zip"
+    Write-Host "  3. 解压后找到 bin/amd64/wintun.dll"
+    Write-Host "  4. 将 wintun.dll 复制到本目录"
+    exit 1
+}
+
+Write-Host "[2/3] 解压 ..." -ForegroundColor Yellow
+try {
+    Expand-Archive -Path "$env:TEMP\$ZipFile" -DestinationPath "$env:TEMP\wintun-extract" -Force
+} catch {
+    Write-Host "[ERROR] 解压失败。请手动解压 $env:TEMP\$ZipFile" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[3/3] 复制 wintun.dll (amd64) 到当前目录 ..." -ForegroundColor Yellow
+$DllPath = "$env:TEMP\wintun-extract\wintun-$WintunVersion\bin\amd64\wintun.dll"
+if (-not (Test-Path $DllPath)) {
+    Write-Host "[ERROR] 未找到 amd64/wintun.dll，请检查 wintun 包结构是否变化" -ForegroundColor Red
+    Write-Host "        预期路径: $DllPath" -ForegroundColor Red
+    exit 1
+}
+
+Copy-Item -Path $DllPath -Destination "$ScriptDir\wintun.dll"
+Remove-Item -Path "$env:TEMP\$ZipFile" -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:TEMP\wintun-extract" -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host ""
+Write-Host "[DONE] wintun.dll 就绪" -ForegroundColor Green
+Write-Host ""
+Write-Host "接下来:" -ForegroundColor Yellow
+Write-Host "  1. 编辑 config.json 填入你的公司代码和账号信息"
+Write-Host "  2. 以管理员身份运行: .\corplink-rs.exe config.json"
+Write-Host ""
+Write-Host "高级用法:" -ForegroundColor Yellow
+Write-Host "  调试日志: `$env:RUST_LOG='debug'; .\corplink-rs.exe config.json"
+Write-Host "  指定服务端: 在 config.json 中设置 'vpn_server_name' 字段"

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,6 +1,6 @@
-# setup.ps1 — corplink-rs Windows 环境准备
-# 自动下载 wintun.dll 到当前目录
-# 用法: powershell -ExecutionPolicy Bypass -File setup.ps1
+# setup.ps1 — corplink-rs Windows environment setup
+# Automatically downloads wintun.dll to the current directory
+# Usage: powershell -ExecutionPolicy Bypass -File setup.ps1
 
 $ErrorActionPreference = "Stop"
 
@@ -12,46 +12,45 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Write-Host "corplink-rs Windows setup" -ForegroundColor Cyan
 Write-Host "========================" -ForegroundColor Cyan
 
-# 检查 wintun.dll 是否已存在
 if (Test-Path "$ScriptDir\wintun.dll") {
     $existing = Get-Item "$ScriptDir\wintun.dll"
-    Write-Host "[OK] wintun.dll 已存在 ($($existing.VersionInfo.FileVersion))，跳过下载" -ForegroundColor Green
+    Write-Host "[OK] wintun.dll found ($($existing.VersionInfo.FileVersion)), skip download" -ForegroundColor Green
     Write-Host ""
-    Write-Host "接下来:" -ForegroundColor Yellow
-    Write-Host "  1. 编辑 config.json 填入你的公司代码和账号信息"
-    Write-Host "  2. 以管理员身份运行: .\corplink-rs.exe config.json"
+    Write-Host "Next steps:" -ForegroundColor Yellow
+    Write-Host "  1. Edit config.json with your company code and account info"
+    Write-Host "  2. Run as Administrator: .\corplink-rs.exe config.json"
     exit 0
 }
 
-Write-Host "[1/3] 下载 wintun.dll (v$WintunVersion) ..." -ForegroundColor Yellow
+Write-Host "[1/3] Downloading wintun.dll (v$WintunVersion) ..." -ForegroundColor Yellow
 Write-Host "        $WintunUrl"
 
 try {
     Invoke-WebRequest -Uri $WintunUrl -OutFile "$env:TEMP\$ZipFile" -UseBasicParsing
 } catch {
-    Write-Host "[ERROR] 下载失败: $_" -ForegroundColor Red
+    Write-Host "[ERROR] Download failed: $_" -ForegroundColor Red
     Write-Host ""
-    Write-Host "请手动下载:" -ForegroundColor Yellow
-    Write-Host "  1. 打开 https://www.wintun.net/"
-    Write-Host "  2. 下载 wintun-$WintunVersion.zip"
-    Write-Host "  3. 解压后找到 bin/amd64/wintun.dll"
-    Write-Host "  4. 将 wintun.dll 复制到本目录"
+    Write-Host "Manual download:" -ForegroundColor Yellow
+    Write-Host "  1. Visit https://www.wintun.net/"
+    Write-Host "  2. Download wintun-$WintunVersion.zip"
+    Write-Host "  3. Extract bin/amd64/wintun.dll"
+    Write-Host "  4. Copy wintun.dll to this directory"
     exit 1
 }
 
-Write-Host "[2/3] 解压 ..." -ForegroundColor Yellow
+Write-Host "[2/3] Extracting ..." -ForegroundColor Yellow
 try {
     Expand-Archive -Path "$env:TEMP\$ZipFile" -DestinationPath "$env:TEMP\wintun-extract" -Force
 } catch {
-    Write-Host "[ERROR] 解压失败。请手动解压 $env:TEMP\$ZipFile" -ForegroundColor Red
+    Write-Host "[ERROR] Extract failed. Manually extract $env:TEMP\$ZipFile" -ForegroundColor Red
     exit 1
 }
 
-Write-Host "[3/3] 复制 wintun.dll (amd64) 到当前目录 ..." -ForegroundColor Yellow
+Write-Host "[3/3] Copying wintun.dll (amd64) ..." -ForegroundColor Yellow
 $DllPath = "$env:TEMP\wintun-extract\wintun-$WintunVersion\bin\amd64\wintun.dll"
 if (-not (Test-Path $DllPath)) {
-    Write-Host "[ERROR] 未找到 amd64/wintun.dll，请检查 wintun 包结构是否变化" -ForegroundColor Red
-    Write-Host "        预期路径: $DllPath" -ForegroundColor Red
+    Write-Host "[ERROR] amd64/wintun.dll not found. The wintun package structure may have changed." -ForegroundColor Red
+    Write-Host "        Expected: $DllPath" -ForegroundColor Red
     exit 1
 }
 
@@ -60,12 +59,11 @@ Remove-Item -Path "$env:TEMP\$ZipFile" -ErrorAction SilentlyContinue
 Remove-Item -Path "$env:TEMP\wintun-extract" -Recurse -Force -ErrorAction SilentlyContinue
 
 Write-Host ""
-Write-Host "[DONE] wintun.dll 就绪" -ForegroundColor Green
+Write-Host "[DONE] wintun.dll is ready" -ForegroundColor Green
 Write-Host ""
-Write-Host "接下来:" -ForegroundColor Yellow
-Write-Host "  1. 编辑 config.json 填入你的公司代码和账号信息"
-Write-Host "  2. 以管理员身份运行: .\corplink-rs.exe config.json"
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "  1. Edit config.json with your company code and account info"
+Write-Host "  2. Run as Administrator: .\corplink-rs.exe config.json"
 Write-Host ""
-Write-Host "高级用法:" -ForegroundColor Yellow
-Write-Host "  调试日志: `$env:RUST_LOG='debug'; .\corplink-rs.exe config.json"
-Write-Host "  指定服务端: 在 config.json 中设置 'vpn_server_name' 字段"
+Write-Host "Debug mode:" -ForegroundColor Yellow
+Write-Host "  `$env:RUST_LOG='debug'; .\corplink-rs.exe config.json"

--- a/src/client.rs
+++ b/src/client.rs
@@ -428,8 +428,9 @@ impl Client {
             }
             let otp_uri = otp_uri?;
             if otp_uri.is_empty() {
-                log::warn!("failed to login with method {method}");
-                continue;
+                log::info!("no otp code from server, will ask for 2fa code when connecting");
+                self.change_state(State::Login).await?;
+                return Ok(());
             }
             self.change_state(State::Login).await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -706,8 +706,16 @@ impl Client {
             }
         }
         if otp.is_empty() {
-            log::info!("input your 2fa code:");
-            otp = utils::read_line().await?;
+            let is_tps_login = matches!(
+                self.conf.platform.as_deref(),
+                Some(PLATFORM_LARK | PLATFORM_OIDC)
+            );
+            if is_tps_login {
+                log::info!("use empty 2fa code (tps login already verified)");
+            } else {
+                log::info!("input your 2fa code:");
+                otp = utils::read_line().await?;
+            }
         }
         let mut m = Map::new();
         m.insert("public_key".to_string(), json!(public_key));

--- a/src/qrcode.rs
+++ b/src/qrcode.rs
@@ -2,6 +2,10 @@ use qrcode::{EcLevel, QrCode, Version};
 use terminal_graphics::Colour;
 use terminal_graphics::Display;
 
+const QR_MIN_VERSION: i16 = 20;
+const QR_MAX_VERSION: i16 = 40;
+const QR_VERSION_STEP: i16 = 4;
+
 #[derive(Clone)]
 pub struct TerminalQrCode {
     code: QrCode,
@@ -10,12 +14,17 @@ pub struct TerminalQrCode {
 impl TerminalQrCode {
     pub fn from_bytes<D: AsRef<[u8]>>(data: D) -> Result<TerminalQrCode, anyhow::Error> {
         let data = data.as_ref();
-        for v in [20i16, 25, 30, 35, 40] {
+        let mut v = QR_MIN_VERSION;
+        loop {
             if let Ok(code) = QrCode::with_version(data, Version::Normal(v), EcLevel::L) {
                 return Ok(TerminalQrCode { code });
             }
+            if v >= QR_MAX_VERSION {
+                break;
+            }
+            v += QR_VERSION_STEP;
         }
-        Err(anyhow::anyhow!("data too long for QR code (max version 40)"))
+        Err(anyhow::anyhow!("data too long for QR code (max version {QR_MAX_VERSION})"))
     }
 
     pub fn print(&self) {

--- a/src/qrcode.rs
+++ b/src/qrcode.rs
@@ -9,8 +9,13 @@ pub struct TerminalQrCode {
 
 impl TerminalQrCode {
     pub fn from_bytes<D: AsRef<[u8]>>(data: D) -> Result<TerminalQrCode, anyhow::Error> {
-        let code: QrCode = QrCode::with_version(data.as_ref(), Version::Normal(20), EcLevel::L)?;
-        Ok(TerminalQrCode { code })
+        let data = data.as_ref();
+        for v in [20i16, 25, 30, 35, 40] {
+            if let Ok(code) = QrCode::with_version(data, Version::Normal(v), EcLevel::L) {
+                return Ok(TerminalQrCode { code });
+            }
+        }
+        Err(anyhow::anyhow!("data too long for QR code (max version 40)"))
     }
 
     pub fn print(&self) {


### PR DESCRIPTION
## 改动内容

三个改进，主要解决飞书（lark）登录用户在 Windows 上的体验问题：

### 1. QR 码容量自适应
登录 URL 过长时，之前会直接报 "data too long"。现在自动尝试更大版本（20→25→30→35→40），确保飞书登录链接能正常生成二维码。

### 2. 空 OTP URI 的登录兜底
飞书扫码授权成功后，如果服务端返回空的 OTP URL（账户没有预置 TOTP），之前会直接判登录失败。现在允许继续登录，连 VPN 时再处理 2FA。

### 3. TPS 登录跳过 2FA 输入
飞书/OIDC 登录本身已经是二次认证，连 VPN 时不再向用户索要 6 位动态码（用户可能根本没有），直接发给服务端空码即可。

### 4. Windows 环境自动化
- 新增 `scripts/setup.ps1`，自动从 wintun.net 下载 wintun.dll 到当前目录
- README 补全了 Windows 编译和使用的详细说明
- CI 的 Windows 发布包加入 setup.ps1

## 测试
- Windows 11 上飞书扫码登录成功
- 空码直连 VPN 成功，10 条内网路由正常下发
- setup.ps1 在 PowerShell 5.1 测试通过