### PR TITLE
feat: userspace netstack/SOCKS5 mode (socks5_listen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,33 @@ RUST_LOG=debug ./corplink-rs config.json
   // "0.0.0.0/0" (full-tunnel). useful for keeping local LAN traffic off the
   // VPN, and for excluding the VPN peer endpoint IP to avoid a routing loop
   // that would otherwise black-hole all traffic.
-  "vpn_disallowed_routes": ["192.168.1.0/24"]
+  "vpn_disallowed_routes": ["192.168.1.0/24"],
+  // optional: run entirely in userspace (gVisor netstack) and expose a SOCKS5
+  // proxy at this address instead of creating a kernel TUN device. No system
+  // interface, routes, DNS changes or root privileges are required.
+  // supports TCP CONNECT and UDP ASSOCIATE; hostnames are resolved in-tunnel.
+  "socks5_listen": "0.0.0.0:1080",
+  // optional: require SOCKS5 username/password auth (RFC 1929) on the proxy.
+  // when socks5_username is empty/unset, the proxy accepts connections with no auth.
+  "socks5_username": "user",
+  "socks5_password": "pass"
 }
 ```
+
+## SOCKS5 / netstack 模式
+
+设置 `socks5_listen` 后，corplink-rs 不再创建内核 TUN 网卡，而是用 [wg-go][2] 的 gVisor netstack 在用户态跑 WireGuard，并在该地址上暴露一个 SOCKS5 代理：
+
+- **无需 root / 不改系统路由和 DNS / 不建网卡**，适合容器、无权限环境或只想给单个应用走 VPN 的场景
+- 支持 TCP `CONNECT` 和 UDP `ASSOCIATE`，域名在隧道内解析（用 `--socks5-hostname` 让客户端把 DNS 也交给代理）
+- 可选用户名/密码认证（RFC 1929）：设置 `socks5_username`（及 `socks5_password`）即开启；留空则免认证
+
+```sh
+# 例：通过代理访问内网
+curl --socks5-hostname user:pass@127.0.0.1:1080 https://intranet.example.com/
+```
+
+此模式下 `interface_name`、`use_vpn_dns`、`auto_setup_routes` 等与系统网卡/路由相关的设置不生效。
 
 # 原理和分析
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,16 @@ pub struct Config {
     /// Useful in full mode to punch holes for local LAN or the VPN peer IP itself,
     /// avoiding routing loops (e.g. 192.168.1.0/24, 10.0.0.5/32).
     pub vpn_disallowed_routes: Option<Vec<String>>,
+    /// When set, run entirely in userspace (gVisor netstack) and expose a SOCKS5
+    /// proxy at this listen address (e.g. "0.0.0.0:1080" or "127.0.0.1:1080")
+    /// instead of creating a kernel TUN device. No system interface, routes, DNS
+    /// changes or root privileges are required. Only TCP CONNECT is supported.
+    pub socks5_listen: Option<String>,
+    /// Optional SOCKS5 username/password authentication (RFC 1929). When
+    /// `socks5_username` is set and non-empty, clients must authenticate with
+    /// these credentials; otherwise the proxy accepts connections without auth.
+    pub socks5_username: Option<String>,
+    pub socks5_password: Option<String>,
 }
 
 impl fmt::Display for Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,6 @@ async fn run() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     print_version();
-    check_privilege();
 
     let conf_file = parse_arg();
     let mut conf = Config::from_file(&conf_file)
@@ -83,6 +82,16 @@ async fn run() -> Result<()> {
         .interface_name
         .clone()
         .context("interface name missing in config")?;
+    let socks5_listen = conf.socks5_listen.clone();
+    let socks5_username = conf.socks5_username.clone().unwrap_or_default();
+    let socks5_password = conf.socks5_password.clone().unwrap_or_default();
+    let netstack_mode = socks5_listen.is_some();
+
+    // netstack/socks5 mode runs entirely in userspace (no kernel TUN device,
+    // no system routes/dns), so it does not require elevated privileges.
+    if !netstack_mode {
+        check_privilege();
+    }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     let use_vpn_dns = conf.use_vpn_dns.unwrap_or(false);
@@ -139,21 +148,38 @@ async fn run() -> Result<()> {
             }
         };
     }
-    log::info!("start wg-corplink for {}", &name);
     let wg_conf = wg_conf.ok_or_else(|| anyhow!("wg conf missing after connect loop"))?;
     let protocol = wg_conf.protocol;
-    wg::start_wg_go(&name, protocol, with_wg_log)
-        .with_context(|| format!("failed to start wg-corplink for {}", name))?;
     let mut uapi = wg::UAPIClient { name: name.clone() };
-    uapi.config_wg(&wg_conf)
-        .await
-        .with_context(|| format!("failed to config interface with uapi for {name}"))?;
+    if let Some(listen) = &socks5_listen {
+        log::info!("start wg-corplink (netstack/socks5) on {}", listen);
+        wg::start_wg_go_netstack(&wg_conf, listen, &socks5_username, &socks5_password, with_wg_log)
+            .context("failed to start wg-corplink in netstack mode")?;
+        uapi.config_wg_netstack(&wg_conf)
+            .await
+            .context("failed to config netstack interface with uapi")?;
+        if socks5_username.is_empty() {
+            log::info!("socks5 proxy ready at {} (no auth)", listen);
+        } else {
+            log::info!(
+                "socks5 proxy ready at {} (username/password auth required)",
+                listen
+            );
+        }
+    } else {
+        log::info!("start wg-corplink for {}", &name);
+        wg::start_wg_go(&name, protocol, with_wg_log)
+            .with_context(|| format!("failed to start wg-corplink for {}", name))?;
+        uapi.config_wg(&wg_conf)
+            .await
+            .with_context(|| format!("failed to config interface with uapi for {name}"))?;
+    }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     let mut dns_manager = DNSManager::new(dns_backup_filename);
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    if use_vpn_dns {
+    if use_vpn_dns && !netstack_mode {
         match dns_manager.set_dns(vec![&wg_conf.dns], vec![]) {
             Ok(_) => {}
             Err(err) => {
@@ -198,7 +224,7 @@ async fn run() -> Result<()> {
     wg::stop_wg_go();
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    if use_vpn_dns {
+    if use_vpn_dns && !netstack_mode {
         match dns_manager.restore_dns() {
             Ok(_) => {}
             Err(err) => {

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -28,6 +28,35 @@ fn stop_wg() {
     }
 }
 
+fn start_wg_netstack(
+    log_level: i32,
+    protocol: i32,
+    addresses: &str,
+    dns: &str,
+    socks_listen: &str,
+    socks_user: &str,
+    socks_pass: &str,
+    mtu: i32,
+) -> Result<i32> {
+    let c_addresses = CString::new(addresses).context("addresses contains null character")?;
+    let c_dns = CString::new(dns).context("dns contains null character")?;
+    let c_socks = CString::new(socks_listen).context("socks_listen contains null character")?;
+    let c_user = CString::new(socks_user).context("socks_user contains null character")?;
+    let c_pass = CString::new(socks_pass).context("socks_pass contains null character")?;
+    unsafe {
+        Ok(libwg::startWgNetstack(
+            log_level,
+            protocol,
+            c_addresses.as_ptr(),
+            c_dns.as_ptr(),
+            c_socks.as_ptr(),
+            c_user.as_ptr(),
+            c_pass.as_ptr(),
+            mtu,
+        ))
+    }
+}
+
 fn uapi(buff: &[u8]) -> Result<Vec<u8>> {
     let input_cstring = CString::new(buff).context("buff contains null character")?;
     unsafe {
@@ -54,6 +83,42 @@ pub fn start_wg_go(name: &str, protocol: i32, with_log: bool) -> Result<()> {
     let ret = start_wg(log_level, protocol, name)?;
     if !matches!(ret, 0) {
         return Err(anyhow!("start_wg returned non-zero code: {ret}"));
+    }
+    Ok(())
+}
+
+// start wg-corplink in userspace netstack mode and expose a SOCKS5 proxy.
+// no kernel TUN device, no system routes/dns and no root are needed.
+pub fn start_wg_go_netstack(
+    conf: &config::WgConf,
+    socks_listen: &str,
+    socks_user: &str,
+    socks_pass: &str,
+    with_log: bool,
+) -> Result<()> {
+    log::info!("start wg-corplink in netstack/socks5 mode");
+    let log_level = if with_log {
+        libwg::LogLevelVerbose
+    } else {
+        libwg::LogLevelError
+    };
+    let mut addrs = vec![conf.address.clone()];
+    if !conf.address6.is_empty() {
+        addrs.push(conf.address6.clone());
+    }
+    let addresses = addrs.join(",");
+    let ret = start_wg_netstack(
+        log_level,
+        conf.protocol,
+        &addresses,
+        &conf.dns,
+        socks_listen,
+        socks_user,
+        socks_pass,
+        conf.mtu as i32,
+    )?;
+    if !matches!(ret, 0) {
+        return Err(anyhow!("start_wg_netstack returned non-zero code: {ret}"));
     }
     Ok(())
 }
@@ -105,6 +170,36 @@ impl UAPIClient {
 
         buff.push('\n');
         log::info!("send config to uapi");
+        let data = uapi(buff.as_bytes()).context("call uapi")?;
+        let s = String::from_utf8(data).context("failed to decode uapi response")?;
+        if !s.contains("errno=0") {
+            return Err(anyhow!("uapi returns unexpected result: {}", s));
+        }
+        Ok(())
+    }
+
+    // configure wg for netstack mode. only the standard wg-go uapi operations
+    // are sent: the interface address/mtu and the device "up" state are handled
+    // by netstack at creation time, and there are no system routes to install.
+    pub async fn config_wg_netstack(&mut self, conf: &config::WgConf) -> Result<()> {
+        let mut buff = String::from("set=1\n");
+        let private_key = utils::b64_decode_to_hex(&conf.private_key)?;
+        let public_key = utils::b64_decode_to_hex(&conf.peer_key)?;
+        buff.push_str(format!("private_key={private_key}\n").as_str());
+        buff.push_str("replace_peers=true\n");
+        buff.push_str(format!("public_key={public_key}\n").as_str());
+        buff.push_str("replace_allowed_ips=true\n");
+        buff.push_str(format!("endpoint={}\n", conf.peer_address).as_str());
+        buff.push_str("persistent_keepalive_interval=10\n");
+        for allowed_ip in &conf.allowed_ips {
+            if allowed_ip.contains("/") {
+                buff.push_str(format!("allowed_ip={allowed_ip}\n").as_str());
+            } else {
+                buff.push_str(format!("allowed_ip={allowed_ip}/32\n").as_str());
+            }
+        }
+        buff.push('\n');
+        log::info!("send netstack config to uapi");
         let data = uapi(buff.as_bytes()).context("call uapi")?;
         let s = String::from_utf8(data).context("failed to decode uapi response")?;
         if !s.contains("errno=0") {


### PR DESCRIPTION
Adds a userspace **netstack/SOCKS5** mode: set `socks5_listen` (e.g. `0.0.0.0:1080`) and corplink-rs runs WireGuard entirely in userspace via gVisor's netstack and exposes a SOCKS5 proxy — no TUN device, no route/DNS changes, **no root**. DNS is resolved inside the tunnel, so internal-only domains work.

- `socks5_listen` — enable the mode + bind address
- `socks5_username` / `socks5_password` — optional SOCKS5 auth (RFC 1929); omit for no-auth
- TCP CONNECT + UDP ASSOCIATE, both routed through the tunnel
- Skips the privilege check / route / DNS setup when in this mode

Depends on PinkD/wireguard-go#3 (the `libwg` netstack + SOCKS5 server). The submodule here points at that PR's head (`f0b1dc0`); per your note, you'll handle the submodule bump once #3 lands in the org.

Companion to #89 (feilian_v1 login). Verified end-to-end (login → connect → SOCKS5 → internal site), including UDP and auth.