### PR TITLE
feat: add CIDR allowlist filtering for VPN routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ RUST_LOG=debug ./corplink-rs config.json
   // - full:  use full-tunnel routes from server
   //          often combined with "auto_setup_routes": false in container/gateway setups
   "route_mode": "split",
+  // optional strict CIDR whitelist. each entry is intersected with the routes
+  // returned by the server, so it can only narrow the VPN routes. an empty list
+  // allows no routes; missing/null preserves the server routes. when both lists
+  // are set, vpn_disallowed_routes is subtracted after this whitelist.
+  "vpn_allowed_routes": ["192.168.2.0/24"],
   // optional: list of CIDRs to carve out of AllowedIPs (and system routes).
   // applied as CIDR subtraction: each entry is subtracted from every route
   // returned by the server, so listing a smaller range like "10.68.0.0/16"

--- a/src/client.rs
+++ b/src/client.rs
@@ -952,33 +952,28 @@ impl Client {
             }
         };
 
-        // Carve user-specified CIDRs out of allowed_ips. This removes any IPs in
-        // vpn_disallowed_routes from the VPN's AllowedIPs (and the system routes
-        // derived from them), which is the standard way to avoid routing loops in
-        // full-tunnel mode — e.g. listing the local LAN or a CIDR covering the
-        // VPN peer endpoint so their packets don't get captured by the tunnel.
-        //
-        // Semantics: CIDR subtraction. An entry like "10.68.0.0/16" carves that
-        // whole range out of each allowed_ip, even when allowed_ip is a larger
-        // supernet such as "0.0.0.0/0" — which expands to a minimal set of
-        // smaller CIDRs covering "allowed minus disallowed".
-        if let Some(disallowed) = self.conf.vpn_disallowed_routes.as_ref() {
-            if !disallowed.is_empty() {
-                let before = allowed_ips.len();
-                for d in disallowed {
-                    let mut carved = Vec::with_capacity(allowed_ips.len());
-                    for a in &allowed_ips {
-                        carved.extend(crate::utils::subtract_cidr_from_cidr(a, d));
-                    }
-                    allowed_ips = carved;
+        // Restrict server routes to the optional whitelist, then carve out the
+        // optional denylist. A configured empty whitelist intentionally yields
+        // no AllowedIPs/routes; invalid whitelist entries fail closed.
+        if let Some(allowed) = self.conf.vpn_allowed_routes.as_deref() {
+            for route in allowed {
+                if !crate::utils::is_valid_cidr(route) {
+                    log::warn!("ignoring invalid vpn_allowed_routes CIDR: {:?}", route);
                 }
-                log::info!(
-                    "vpn_disallowed_routes applied: {} -> {} entries (carved: {:?})",
-                    before,
-                    allowed_ips.len(),
-                    disallowed
-                );
             }
+        }
+        let before = allowed_ips.len();
+        allowed_ips = crate::utils::apply_route_filters(
+            &allowed_ips,
+            self.conf.vpn_allowed_routes.as_deref(),
+            self.conf.vpn_disallowed_routes.as_deref(),
+        );
+        if self.conf.vpn_allowed_routes.is_some() || self.conf.vpn_disallowed_routes.is_some() {
+            log::info!(
+                "VPN route filters applied: {} -> {} entries",
+                before,
+                allowed_ips.len()
+            );
         }
 
         // Auto-carve the VPN peer endpoint IP out of allowed_ips. In full-tunnel mode

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,9 @@ pub struct Config {
     pub auto_setup_routes: Option<bool>,
     /// "split" (default) or "full". Selects which route list from the server to apply.
     pub route_mode: Option<RouteMode>,
+    /// Optional CIDR whitelist intersected with server routes.
+    /// Missing/null preserves server routes; an empty list allows no routes.
+    pub vpn_allowed_routes: Option<Vec<String>>,
     /// Optional list of CIDR routes to exclude from AllowedIPs / system routes.
     /// Useful in full mode to punch holes for local LAN or the VPN peer IP itself,
     /// avoiding routing loops (e.g. 192.168.1.0/24, 10.0.0.5/32).
@@ -101,7 +104,7 @@ impl fmt::Display for Config {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match serde_json::to_string_pretty(self) {
             Ok(s) => write!(f, "{}", s),
-            Err(e) => write!(f, "<invalid config: {e}>")
+            Err(e) => write!(f, "<invalid config: {e}>"),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,6 +77,67 @@ pub fn feilian_v1_encrypt_password(password: &str) -> String {
     hex::encode(ct)
 }
 
+/// Returns whether `cidr` is a parseable IPv4 or IPv6 CIDR.
+pub fn is_valid_cidr(cidr: &str) -> bool {
+    parse_cidr(cidr).is_some()
+}
+
+/// Returns the intersection of two CIDRs, or `None` when they are disjoint,
+/// use different address families, or either input is invalid.
+pub fn intersect_cidr_with_cidr(first: &str, second: &str) -> Option<String> {
+    let (first_base, first_prefix) = parse_cidr(first)?;
+    let (second_base, second_prefix) = parse_cidr(second)?;
+    if !same_family(first_base, second_base) {
+        return None;
+    }
+    if first_prefix >= second_prefix
+        && cidr_contains_ip(second_base, second_prefix, first_base)
+    {
+        return Some(format!("{first_base}/{first_prefix}"));
+    }
+    if second_prefix >= first_prefix
+        && cidr_contains_ip(first_base, first_prefix, second_base)
+    {
+        return Some(format!("{second_base}/{second_prefix}"));
+    }
+    None
+}
+
+/// Applies the optional CIDR allowlist, followed by the optional denylist, to
+/// server-supplied routes. A missing allowlist preserves the server routes,
+/// while an explicitly empty allowlist permits no routes.
+pub fn apply_route_filters(
+    server_routes: &[String],
+    allowed_routes: Option<&[String]>,
+    disallowed_routes: Option<&[String]>,
+) -> Vec<String> {
+    let mut routes = match allowed_routes {
+        None => server_routes.to_vec(),
+        Some(allowed) => {
+            let mut intersections = Vec::new();
+            for server in server_routes {
+                for allowed_route in allowed {
+                    if let Some(route) = intersect_cidr_with_cidr(server, allowed_route) {
+                        if !intersections.contains(&route) {
+                            intersections.push(route);
+                        }
+                    }
+                }
+            }
+            intersections
+        }
+    };
+    if let Some(disallowed) = disallowed_routes {
+        for excluded in disallowed {
+            routes = routes
+                .iter()
+                .flat_map(|route| subtract_cidr_from_cidr(route, excluded))
+                .collect();
+        }
+    }
+    routes
+}
+
 /// Returns a list of CIDR strings covering all addresses in `outer` except those in `inner`.
 ///
 /// - Disjoint (no overlap) → `[outer]` unchanged.
@@ -237,6 +298,83 @@ mod tests {
             }
             _ => false,
         }
+    }
+
+    #[test]
+    fn intersect_returns_the_narrower_cidr() {
+        assert_eq!(
+            intersect_cidr_with_cidr("10.0.0.0/8", "10.1.0.0/16"),
+            Some("10.1.0.0/16".to_string())
+        );
+        assert_eq!(
+            intersect_cidr_with_cidr("10.1.0.0/16", "10.0.0.0/8"),
+            Some("10.1.0.0/16".to_string())
+        );
+    }
+
+    #[test]
+    fn intersect_rejects_disjoint_invalid_and_mixed_family_cidrs() {
+        assert_eq!(
+            intersect_cidr_with_cidr("10.0.0.0/8", "192.168.0.0/16"),
+            None
+        );
+        assert_eq!(
+            intersect_cidr_with_cidr("10.0.0.0/8", "2001:db8::/32"),
+            None
+        );
+        assert_eq!(intersect_cidr_with_cidr("10.0.0.0/8", "invalid"), None);
+    }
+
+    #[test]
+    fn intersect_supports_ipv6_and_canonicalizes_the_result() {
+        assert_eq!(
+            intersect_cidr_with_cidr("2001:db8::/32", "2001:db8:1::7/48"),
+            Some("2001:db8:1::/48".to_string())
+        );
+    }
+
+    #[test]
+    fn route_filters_deduplicate_intersections_in_stable_order() {
+        let server = vec!["10.0.0.0/8".to_string(), "192.168.0.0/16".to_string()];
+        let allowed = vec![
+            "192.168.1.0/24".to_string(),
+            "10.1.0.0/16".to_string(),
+            "10.1.0.0/16".to_string(),
+        ];
+        assert_eq!(
+            apply_route_filters(&server, Some(allowed.as_slice()), None),
+            vec!["10.1.0.0/16", "192.168.1.0/24"]
+        );
+    }
+
+    #[test]
+    fn route_filters_distinguish_missing_and_empty_allowlists() {
+        let server = vec!["10.0.0.0/8".to_string()];
+        assert_eq!(apply_route_filters(&server, None, None), server);
+        assert!(apply_route_filters(&server, Some(&[]), None).is_empty());
+    }
+
+    #[test]
+    fn route_filters_fail_closed_for_invalid_allowlist_entries() {
+        let server = vec!["10.0.0.0/8".to_string()];
+        let allowed = vec!["invalid".to_string()];
+        assert!(apply_route_filters(&server, Some(allowed.as_slice()), None).is_empty());
+    }
+
+    #[test]
+    fn route_filters_apply_allowlist_before_denylist() {
+        let server = vec!["10.0.0.0/8".to_string()];
+        let allowed = vec!["10.1.0.0/16".to_string()];
+        let disallowed = vec!["10.1.1.0/24".to_string()];
+        let out = apply_route_filters(
+            &server,
+            Some(allowed.as_slice()),
+            Some(disallowed.as_slice()),
+        );
+        assert_eq!(
+            sorted(out),
+            sorted(subtract_cidr_from_cidr("10.1.0.0/16", "10.1.1.0/24"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add the `vpn_allowed_routes` configuration option to restrict server-provided VPN routes to explicitly allowed CIDRs.
- Support IPv4 and IPv6 CIDR intersection.
- Apply the existing `vpn_disallowed_routes` denylist after allowlist filtering.
- Preserve server routes when the allowlist is omitted or `null`, while an empty allowlist permits no routes.
- Ignore invalid allowlist entries safely and log a warning.
- Document the new configuration option in the README.

## Testing

Added unit tests covering:

- CIDR intersection and canonicalization
- IPv4 and IPv6 routes
- Disjoint, invalid, and mixed-family CIDRs
- Missing and empty allowlists
- Stable deduplication
- Combined allowlist and denylist filtering